### PR TITLE
DBのデータをリロードを挟まずに反映するよう変更

### DIFF
--- a/src/pages/manageItems.vue
+++ b/src/pages/manageItems.vue
@@ -4,10 +4,15 @@ const product_name = ref('')
 const eating_allowed = ref('')
 const image_url = ref('')
 const delete_id = ref('')
-const { data: items } = useFetch('/api/fridge_items')
+const items = ref([])
 
-const addItem = () => {
-  useFetch('/api/fridge_items', {
+const fetchItems = async () => {
+  const { data } = await useFetch('/api/fridge_items')
+  items.value = data.value
+}
+
+const addItem = async () => {
+  await useFetch('/api/fridge_items', {
     method: 'post',
     body: {
       owner_name: owner_name.value,
@@ -20,17 +25,22 @@ const addItem = () => {
   product_name.value = ''
   eating_allowed.value = ''
   image_url.value = ''
+  fetchItems()  // リストを更新
 }
 
-const deleteItem = () => {
-  useFetch('/api/fridge_items', {
+const deleteItem = async () => {
+  await useFetch('/api/fridge_items', {
     method: 'delete',
     body: {
       delete_id: delete_id.value,
     },
   })
   delete_id.value = ''
+  fetchItems()  // リストを更新
 }
+
+// 初回読み込み時にデータを取得
+fetchItems()
 </script>
 
 <template>
@@ -118,7 +128,7 @@ const deleteItem = () => {
         >
         <br>
         <button type="submit">
-          削除
+        削除
         </button>
       </div>
     </form>


### PR DESCRIPTION
`items`変数を`ref`に設定しました。
また、`fetchItems`関数(`useFetch`によりDBからデータを取得する)を初回ロード時、データの追加・削除時等に呼び出すことで`items`変数が上書きされ、`ref`に設定している`items`変数にリアルタイムで更新されるようです。(GPT談)

今後別関数(`editItem`とか)を作る時も、関数の最後の処理として`fetchItems()`を入れれば上手く更新されるはずです。