### PR TITLE
表を少し見やすくした

### DIFF
--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -207,12 +207,11 @@
 import { ref, computed, watch } from 'vue'
 
 const headers = ref([
-  { title: 'ID', key: 'id' },
-  { title: 'Owner', key: 'owner_name' },
-  { title: 'Date', key: 'uploaded_at' },
-  { title: 'Name', key: 'product_name' },
   { title: 'Take', key: 'eating_allowed' },
   { title: 'Photo', key: 'image_url' },
+  { title: 'Name', key: 'product_name' },
+  { title: 'Owner', key: 'owner_name' },
+  { title: 'Date', key: 'uploaded_at' },
   { title: '', key: 'selected' },
 ])
 const menuItems = ref([

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -49,6 +49,7 @@
           :headers="headers"
           :items="filteredRows"
           item-value="id"
+          items-per-page="-1"
           class="elevation-1"
         >
           <template #item.eating_allowed="{ item }">

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -51,6 +51,13 @@
           item-value="id"
           class="elevation-1"
         >
+          <template #item.eating_allowed="{ item }">
+            <div
+              v-if="item.eating_allowed"
+            >
+              Free!
+            </div>
+          </template>
           <template #item.selected="{ item }">
             <v-checkbox
               v-if="showCheckboxes"


### PR DESCRIPTION
resolve #48 #59 #63 #67 

## できたこと
### 重要な情報を左に寄せた。
左から、
- 取っていいか
- 写真
- 商品名
- オーナー
- 日付
の順にした。

### Take free? の表示をマシにした
Take freeのものだけ、Free! がつくようにした

### 1ページあたりの商品数10のデフォルトの制限を取り払った
冷蔵庫の容量は限られているため、不要と判断した

## まだ出来ていないこと
- 1つの商品に対して1行ではなく、複数行で、いい感じのレイアウトにして表示したい
  こんな感じ?
![image](https://github.com/KIT-HI-ProgrammingContestGroupC/fridge-manager/assets/74660186/5be5b548-e202-4eda-a8a0-e5020dc99f42)

- Take freeに色つけるとか、もっといい方法がありそう